### PR TITLE
feat: (ship ahead) health & heartbeat endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Style/Documentation:
   Exclude:
     - 'config/initializers/*.rb'
     - 'db/migrate/*.rb'
+    - 'app/controllers/api/v1/health_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/controllers/users/**/*'

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -3,11 +3,8 @@
 module Api
   module V1
     class HealthController < ApplicationController
-      skip_before_action :verify_authenticity_token
-      skip_before_action :doorkeeper_authorize!
-
       def index
-        render json: { status: 'OK', message: 'API is healthy' }
+        render json: { message: 'API is healthy' }
       end
     end
   end

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class HealthController < ApplicationController
+      skip_before_action :verify_authenticity_token
+      skip_before_action :doorkeeper_authorize!
+
+      def index
+        render json: { status: 'OK', message: 'API is healthy' }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -6,6 +6,11 @@ module Api
       def index
         render json: { message: 'API is healthy' }
       end
+
+      def heartbeat
+        # TODO: Add logic to return response time for the API
+        head :not_implemented
+      end
     end
   end
 end

--- a/config/allowed_hosts.yml
+++ b/config/allowed_hosts.yml
@@ -2,6 +2,7 @@ development:
   - api.storysprout.ngrok.io
 test:
   - api.storysprout.test
+  - www.example.com
 production:
   - api.storysprout.app
   - storyteller-f0pp.onrender.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       end
 
       resources :stories, only: %i[create update index show destroy]
+
       get :health, controller: :health, action: :index
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :stories, only: %i[create update index show destroy]
 
       get :health, controller: :health, action: :index
+      get :heartbeat, controller: :health, action: :heartbeat
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,15 +16,15 @@ Rails.application.routes.draw do
       get 'apple/token', controller: :apple, action: :token
     end
 
-    namespace :v1 do
+    namespace :v1, format: :json do
       namespace :webhooks do
         namespace :apple do
           resources :notifications, only: %i[create]
         end
       end
-    end
-    namespace :v1 do
+
       resources :stories, only: %i[create update index show destroy]
+      get :health, controller: :health, action: :index
     end
   end
 

--- a/spec/requests/api/v1/health_spec.rb
+++ b/spec/requests/api/v1/health_spec.rb
@@ -4,9 +4,16 @@ require 'rails_helper'
 
 RSpec.describe 'api/v1/health', type: :request do
   describe 'GET /index' do
-    it 'returns http success' do
+    it 'returns http :ok' do
       get api_v1_health_url, as: :json
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /heartbeat' do
+    it 'returns http :not_implemented' do
+      get api_v1_heartbeat_url, as: :json
+      expect(response).to have_http_status(:not_implemented)
     end
   end
 end

--- a/spec/requests/api/v1/health_spec.rb
+++ b/spec/requests/api/v1/health_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'api/v1/health', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get api_v1_health_url, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Jira Card
<!--- Please link the Jira card here -->

[STORYAI-###](https://larcity.atlassian.net/browse/STORYAI-###)

## Summary
<!--- Describe your changes, keeping in mind the Jira card should hold most of the context -->

> Focus on what's important to note here. The Jira card should provide the rest the context.

Our current plan with Render has the app sometimes spooling down to 0 instances. When a customer makes a request in this state, the app can take over 20 seconds to respond. This PR will enable a FE change to pre-emptively send a BE heartbeat request to wake up the server as soon as the customer hits the landing page before they need to authenticate or make any other workflow critical BE request

## Screenshots (if appropriate):

## Review app(s)

<!-- These should come from Vercel or Render -->

- <storyteller-ui-git-###-donnadieu.vercel.app>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the README/confluence documentation.
- [ ] I have updated the relevant documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
